### PR TITLE
Cleanup - squid:S1197 - Array designators should be on the type, not …

### DIFF
--- a/src/main/java/com/marginallyclever/robotOverlord/DeltaRobot3/DeltaRobot3MotionState.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/DeltaRobot3/DeltaRobot3MotionState.java
@@ -5,7 +5,7 @@ import javax.vecmath.Vector3f;
 
 public class DeltaRobot3MotionState {
 	// angle of rotation
-	DeltaRobot3Arm arms[];
+	DeltaRobot3Arm[] arms;
 
 	public static final int NUM_ARMS = 3;
 

--- a/src/main/java/com/marginallyclever/robotOverlord/EvilMinion/EvilMinionRobot.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/EvilMinion/EvilMinionRobot.java
@@ -786,7 +786,7 @@ extends RobotWithConnection {
 		
 		if( isPortConfirmed ) {
 			if(line.startsWith("A")) {
-				String items[] = line.split(" ");
+				String[] items = line.split(" ");
 				if(items.length>=5) {
 					for(int i=0;i<items.length;++i) {
 						if(items[i].startsWith("A")) {

--- a/src/main/java/com/marginallyclever/robotOverlord/MantisRobot/MantisRobot.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/MantisRobot/MantisRobot.java
@@ -907,7 +907,7 @@ extends RobotWithConnection {
 		
 		if( isPortConfirmed ) {
 			if(line.startsWith("A")) {
-				String items[] = line.split(" ");
+				String[] items = line.split(" ");
 				if(items.length>=5) {
 					for(int i=0;i<items.length;++i) {
 						if(items[i].startsWith("A")) {

--- a/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2MotionState.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2MotionState.java
@@ -14,7 +14,7 @@ public class RotaryStewartPlatform2MotionState implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	// angle of rotation
-	protected RotaryStewartPlatform2Arm arms[];
+	protected RotaryStewartPlatform2Arm[] arms;
 
 	// Relative to base unless otherwise noted.
 	public Vector3f relative = new Vector3f();

--- a/src/main/java/com/marginallyclever/robotOverlord/model/Model.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/model/Model.java
@@ -37,7 +37,7 @@ public class Model implements Serializable {
 	protected transient FloatBuffer vertices;
 	protected transient FloatBuffer normals;
 	protected transient FloatBuffer textureCoordinates;
-	protected transient int VBO[] = null;
+	protected transient int[] VBO = null;
 	protected transient boolean isLoaded = false;
 	protected transient boolean isBinary = false;
 	protected transient float loadScale=1.0f;
@@ -212,7 +212,7 @@ public class Model implements Serializable {
 					continue;
 				}
 				line = line.trim();
-				String c[] = line.split(" ");
+				String[] c = line.split(" ");
 				if(j==0) {
 					x=Float.parseFloat(c[0]);
 					y=Float.parseFloat(c[1]);

--- a/src/main/java/com/marginallyclever/robotOverlord/world/World.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/world/World.java
@@ -89,9 +89,9 @@ implements Serializable {
 
         // add a settings toggle for this option, it really slows down older machines.
         gl2.glEnable(GL2.GL_MULTISAMPLE);
-        
-        int buf[] = new int[1];
-        int sbuf[] = new int[1];
+
+        int[] buf = new int[1];
+        int[] sbuf = new int[1];
         gl2.glGetIntegerv(GL2.GL_SAMPLES, buf, 0);
         gl2.glGetIntegerv(GL2.GL_SAMPLE_BUFFERS, sbuf, 0);
         


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat
