### PR TITLE
Cleanup - squid:UselessParenthesesCheck - Useless parentheses around …

### DIFF
--- a/src/main/java/Generators/HilbertCurveGenerator.java
+++ b/src/main/java/Generators/HilbertCurveGenerator.java
@@ -188,7 +188,7 @@ public class HilbertCurveGenerator implements GcodeGenerator {
     	double newx =  Math.cos(n) * turtle_dx + Math.sin(n) * turtle_dy;
     	double newy = -Math.sin(n) * turtle_dx + Math.cos(n) * turtle_dy;
     	double len = Math.sqrt(newx*newx + newy*newy);
-    	assert(len>0);
+    	assert len>0;
     	turtle_dx = (float)(newx/len);
     	turtle_dy = (float)(newy/len);
     }

--- a/src/main/java/Generators/LoadGCodeGenerator.java
+++ b/src/main/java/Generators/LoadGCodeGenerator.java
@@ -31,7 +31,7 @@ public class LoadGCodeGenerator implements GcodeGenerator {
 		//String filename = (recentFiles[0].length()>0) ? filename=recentFiles[0] : "";
 		String filename="";
 
-		FileFilter filterGCODE = new FileNameExtensionFilter(("GCode"), "ngc");
+		FileFilter filterGCODE = new FileNameExtensionFilter("GCode", "ngc");
 		//FileFilter filterImage = new FileNameExtensionFilter(("Image"), "jpg", "jpeg", "png", "wbmp", "bmp", "gif");
 		//FileFilter filterDXF   = new FileNameExtensionFilter(("DXF"), "dxf");
 		 

--- a/src/main/java/Generators/YourMessageHereGenerator.java
+++ b/src/main/java/Generators/YourMessageHereGenerator.java
@@ -172,8 +172,8 @@ public class YourMessageHereGenerator implements GcodeGenerator {
 
 			TextCreateMessageNow(text,output);
 
-			output.write(("G90;\n"));
-			output.write(("G0 Z15 F"+feed_rate_rapid+";\n"));
+			output.write("G90;\n");
+			output.write("G0 Z15 F"+feed_rate_rapid+";\n");
 			
         	output.flush();
 	        output.close();
@@ -412,7 +412,7 @@ public class YourMessageHereGenerator implements GcodeGenerator {
 			xmin = posx - w;
 			break;
 		default:
-			assert(false);
+			assert false;
 		}
 		
 		switch(align_vertical) {
@@ -429,7 +429,7 @@ public class YourMessageHereGenerator implements GcodeGenerator {
 			ymin = posy - h;
 			break;
 		default:
-			assert(false);
+			assert false;
 		}
 		/*
 		System.out.println(num_lines + " lines");

--- a/src/main/java/com/marginallyclever/robotOverlord/DeltaRobot3/DeltaRobot3.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/DeltaRobot3/DeltaRobot3.java
@@ -33,14 +33,14 @@ extends RobotWithConnection {
 	public final static String ROBOT_NAME = "Delta Robot 3";
 	
 	//machine dimensions & calibration
-	static final float BASE_TO_SHOULDER_X   =( 0.0f);  // measured in solidworks, relative to base origin
-	static final float BASE_TO_SHOULDER_Y   =( 3.77f);
-	static final float BASE_TO_SHOULDER_Z   =(18.9f);
-	static final float BICEP_LENGTH         =( 5.000f);
-	static final float FOREARM_LENGTH       =(16.50f);
-	static final float WRIST_TO_FINGER_X    =( 0.0f);
-	static final float WRIST_TO_FINGER_Y    =( 1.724f);
-	static final float WRIST_TO_FINGER_Z    =( 0.5f);  // measured in solidworks, relative to finger origin
+	static final float BASE_TO_SHOULDER_X   = 0.0f;  // measured in solidworks, relative to base origin
+	static final float BASE_TO_SHOULDER_Y   = 3.77f;
+	static final float BASE_TO_SHOULDER_Z   = 18.9f;
+	static final float BICEP_LENGTH         = 5.000f;
+	static final float FOREARM_LENGTH       = 16.50f;
+	static final float WRIST_TO_FINGER_X    = 0.0f;
+	static final float WRIST_TO_FINGER_Y    = 1.724f;
+	static final float WRIST_TO_FINGER_Z    = 0.5f;  // measured in solidworks, relative to finger origin
 	
 	protected float HOME_X = 0.0f;
 	protected float HOME_Y = 0.0f;
@@ -133,7 +133,7 @@ extends RobotWithConnection {
 
 		// find the starting height of the end effector at home position
 		// @TODO: project wrist-on-bicep to get more accurate distance
-		float aa=(motionNow.arms[0].elbow.y-motionNow.arms[0].wrist.y);
+		float aa= motionNow.arms[0].elbow.y-motionNow.arms[0].wrist.y;
 		float cc=FOREARM_LENGTH;
 		float bb=(float)Math.sqrt((cc*cc)-(aa*aa));
 		aa=motionNow.arms[0].elbow.x-motionNow.arms[0].wrist.x;
@@ -222,7 +222,7 @@ extends RobotWithConnection {
 		// y' = ( -v*(- u*x - v*y - w*z)) * (1.0-C) + y*C + ( + w*x - u*z)*S
 		// z' = ( -w*(- u*x - v*y - w*z)) * (1.0-C) + z*C + ( - v*x + u*y)*S
 		
-		float a = (-u*x - v*y - w*z);
+		float a = -u*x - v*y - w*z;
 
 		return new Vector3f( (-u*a) * (1.0f-C) + x*C + ( -w*y + v*z)*S,
 							 (-v*a) * (1.0f-C) + y*C + (  w*x - u*z)*S,

--- a/src/main/java/com/marginallyclever/robotOverlord/EvilMinion/EvilMinionRobot.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/EvilMinion/EvilMinionRobot.java
@@ -944,7 +944,7 @@ extends RobotWithConnection {
 		// y' = ( -v*(- u*x - v*y - w*z)) * (1.0-C) + y*C + ( + w*x - u*z)*S
 		// z' = ( -w*(- u*x - v*y - w*z)) * (1.0-C) + z*C + ( - v*x + u*y)*S
 		
-		float a = (-u*x - v*y - w*z);
+		float a = -u*x - v*y - w*z;
 
 		return new Vector3f( (-u*a) * (1.0f-C) + x*C + ( -w*y + v*z)*S,
 							 (-v*a) * (1.0f-C) + y*C + (  w*x - u*z)*S,

--- a/src/main/java/com/marginallyclever/robotOverlord/EvilMinionTool/EvilMinionToolGripper.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/EvilMinionTool/EvilMinionToolGripper.java
@@ -173,7 +173,7 @@ public class EvilMinionToolGripper extends EvilMinionTool {
 		gl2.glPopMatrix();
 		// gripper
 		gl2.glPushMatrix();
-		gl2.glTranslated(5.575-2.935+5.55,(-1.395-1.38),0);
+		gl2.glTranslated(5.575-2.935+5.55, -1.395-1.38, 0);
 		gl2.glRotatef(180,0,0,1);
 		d = 2.965;
 		gl2.glTranslated(c*-d,-s*-d,0);

--- a/src/main/java/com/marginallyclever/robotOverlord/IntersectionTester.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/IntersectionTester.java
@@ -35,8 +35,8 @@ public class IntersectionTester {
 	        tD = c;
 	    }
 	    else {                 // get the closest points on the infinite lines
-	        sN = (b*e - c*d);
-	        tN = (a*e - b*d);
+	        sN = b*e - c*d;
+	        tN = a*e - b*d;
 	        if (sN < 0.0) {        // sc < 0 => the s=0 edge is visible
 	            sN = 0.0f;
 	            tN = e;
@@ -69,7 +69,7 @@ public class IntersectionTester {
 	        else if ((-d + b) > a)
 	            sN = sD;
 	        else {
-	            sN = (-d +  b);
+	            sN = -d +  b;
 	            sD = a;
 	        }
 	    }

--- a/src/main/java/com/marginallyclever/robotOverlord/MantisRobot/MantisRobot.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/MantisRobot/MantisRobot.java
@@ -1066,7 +1066,7 @@ extends RobotWithConnection {
 		// y' = ( -v*(- u*x - v*y - w*z)) * (1.0-C) + y*C + ( + w*x - u*z)*S
 		// z' = ( -w*(- u*x - v*y - w*z)) * (1.0-C) + z*C + ( - v*x + u*y)*S
 		
-		float a = (-u*x - v*y - w*z);
+		float a = -u*x - v*y - w*z;
 
 		return new Vector3f( (-u*a) * (1.0f-C) + x*C + ( -w*y + v*z)*S,
 							 (-v*a) * (1.0f-C) + y*C + (  w*x - u*z)*S,

--- a/src/main/java/com/marginallyclever/robotOverlord/MantisTool/MantisToolGripper.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/MantisTool/MantisToolGripper.java
@@ -165,7 +165,7 @@ public class MantisToolGripper extends MantisTool {
 		gl2.glPopMatrix();
 		// gripper
 		gl2.glPushMatrix();
-		gl2.glTranslated(5.575-2.935+5.55,(-1.395-1.38),0);
+		gl2.glTranslated(5.575-2.935+5.55, -1.395-1.38, 0);
 		gl2.glRotatef(180,0,0,1);
 		d = 2.965;
 		gl2.glTranslated(c*-d,-s*-d,0);

--- a/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2.java
@@ -35,14 +35,14 @@ extends RobotWithConnection
 	public static final String ROBOT_NAME = "Stewart Platorm 2";
 	
 	// machine dimensions
-	public static final float BASE_TO_SHOULDER_X   =( 8.093f);  // measured in solidworks, relative to base origin
-	public static final float BASE_TO_SHOULDER_Y   =( 2.150f);
-	public static final float BASE_TO_SHOULDER_Z   =( 6.610f);
-	public static final float BICEP_LENGTH         =( 5.000f);
-	public static final float FOREARM_LENGTH       =(16.750f);
-	public static final float WRIST_TO_FINGER_X    =( 7.635f);
-	public static final float WRIST_TO_FINGER_Y    =( 0.553f);
-	public static final float WRIST_TO_FINGER_Z    =(-0.870f);  // measured in solidworks, relative to finger origin
+	public static final float BASE_TO_SHOULDER_X   = 8.093f;  // measured in solidworks, relative to base origin
+	public static final float BASE_TO_SHOULDER_Y   = 2.150f;
+	public static final float BASE_TO_SHOULDER_Z   = 6.610f;
+	public static final float BICEP_LENGTH         = 5.000f;
+	public static final float FOREARM_LENGTH       = 16.750f;
+	public static final float WRIST_TO_FINGER_X    = 7.635f;
+	public static final float WRIST_TO_FINGER_Y    = 0.553f;
+	public static final float WRIST_TO_FINGER_Z    = -0.870f;  // measured in solidworks, relative to finger origin
 	
 	// calibration settings
 	protected float HOME_X;
@@ -278,7 +278,7 @@ extends RobotWithConnection
 		// y' = ( -v*(- u*x - v*y - w*z)) * (1.0-C) + y*C + ( + w*x - u*z)*S
 		// z' = ( -w*(- u*x - v*y - w*z)) * (1.0-C) + z*C + ( - v*x + u*y)*S
 		
-		float a = (-u*x - v*y - w*z);
+		float a = -u*x - v*y - w*z;
 
 		return new Vector3f( (-u*a) * (1.0f-C) + x*C + ( -w*y + v*z)*S,
 							 (-v*a) * (1.0f-C) + y*C + (  w*x - u*z)*S,

--- a/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2MotionState.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2MotionState.java
@@ -74,7 +74,7 @@ public class RotaryStewartPlatform2MotionState implements Serializable {
 		
 		// find the starting height of the end effector at home position
 		// @TODO: project wrist-on-bicep to get more accurate distance
-		float aa=(this.arms[0].elbow.y-this.arms[0].wrist.y);
+		float aa=this.arms[0].elbow.y-this.arms[0].wrist.y;
 		float cc=RotaryStewartPlatform2.FOREARM_LENGTH;
 		float bb=(float)Math.sqrt((cc*cc)-(aa*aa));
 		aa=this.arms[0].elbow.x-this.arms[0].wrist.x;

--- a/src/main/java/com/marginallyclever/robotOverlord/Spidee/Spidee.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/Spidee/Spidee.java
@@ -1025,7 +1025,7 @@ implements ActionListener {
 	  int strafe_direction = buttons[BUTTONS_X_POS]
 	                       - buttons[BUTTONS_X_NEG];
 
-	  boolean update=( turn_direction != 0 || walk_direction != 0 || strafe_direction != 0 );
+	  boolean update= turn_direction != 0 || walk_direction != 0 || strafe_direction != 0;
 
 	  // zero stance width
 	  if(buttons[BUTTONS_1]>0) {  // widen stance
@@ -1073,8 +1073,8 @@ implements ActionListener {
 	    turn_direction = (int)Math.max(Math.min( (float)turn_direction, 180*dt), -180*dt );
 	    float turn = (float)Math.toRadians(turn_direction * turn_stride_length) * dt * move_body_scale / 6.0f;
 
-	    float c=( (float)Math.cos( turn ) );
-	    float s=( (float)Math.sin( turn ) );
+	    float c= (float)Math.cos( turn );
+	    float s= (float)Math.sin( turn );
 
 	    for(i=0;i<6;++i) {
 	      SpideeLeg leg = legs[i];
@@ -1253,8 +1253,8 @@ implements ActionListener {
 
 	  Update_Gait_Target(dt,1.0f/6.0f);
 
-	  float step=( gait_cycle - (float)Math.floor( gait_cycle ) );
-	  int leg_to_move=( (int)Math.floor( gait_cycle ) % 6 );
+	  float step= gait_cycle - (float)Math.floor( gait_cycle );
+	  int leg_to_move= (int)Math.floor( gait_cycle ) % 6;
 
 	  // put all feet down except the "active" leg(s).
 	  int i;
@@ -1330,8 +1330,8 @@ implements ActionListener {
 
 	  Update_Gait_Target(dt,0.5f);
 
-	  float step=( gait_cycle - (float)Math.floor( gait_cycle ) );
-	  int leg_to_move=( (int)Math.floor( gait_cycle ) % 2 );
+	  float step= gait_cycle - (float)Math.floor( gait_cycle );
+	  int leg_to_move= (int)Math.floor( gait_cycle ) % 2;
 
 	  // put all feet down except the "active" leg(s).
 	  int i;
@@ -1411,8 +1411,8 @@ implements ActionListener {
 	    ds.sub( body.pos );
 	    Vector3f df = new Vector3f( leg.ankle_joint.pos );
 	    df.sub( body.pos );
-	    float dfl=( df.length() );
-	    float dsl=( ds.length() );
+	    float dfl= df.length();
+	    float dsl= ds.length();
 
 	    ds.z = 0;
 	    ds.normalize();
@@ -1532,7 +1532,7 @@ implements ActionListener {
 	    float knee_angle = (float)Math.atan2( y, x );
 
 	    // translate the angles into the servo range, 0...255 over 0...PI.
-	    final float scale = ( 255.0f / (float)Math.PI );
+	    final float scale = 255.0f / (float)Math.PI;
 	    if( i < 3 ) pan_angle = -pan_angle;
 	    float p = leg.pan_joint .zero - pan_angle  * leg.pan_joint .scale * scale;
 	    float t = leg.tilt_joint.zero + tilt_angle * leg.tilt_joint.scale * scale;

--- a/src/main/java/com/marginallyclever/robotOverlord/Spidee/SpideeControlPanel.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/Spidee/SpideeControlPanel.java
@@ -199,43 +199,43 @@ public class SpideeControlPanel extends JPanel implements ChangeListener, Action
 		  buttons[BUTTONS_0]         = (int) Input.GetSingleton().GetAxisState("spidee","recenter");
 */
 		if( subject == buttonWalkUp ) {
-			robot.buttons[Spidee.BUTTONS_Z_POS] = (robot.buttons[Spidee.BUTTONS_Z_POS]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_Z_POS] = robot.buttons[Spidee.BUTTONS_Z_POS]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_Z_NEG] = 0;
 		}
 		if( subject == buttonWalkDown ) {
-			robot.buttons[Spidee.BUTTONS_Z_NEG] = (robot.buttons[Spidee.BUTTONS_Z_NEG]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_Z_NEG] = robot.buttons[Spidee.BUTTONS_Z_NEG]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_Z_POS] = 0;
 		}
 		if( subject == buttonWalkLeft ) {
-			robot.buttons[Spidee.BUTTONS_X_POS] = (robot.buttons[Spidee.BUTTONS_X_POS]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_X_POS] = robot.buttons[Spidee.BUTTONS_X_POS]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_X_NEG] = 0;
 		}
 		if( subject == buttonWalkRight ) {
-			robot.buttons[Spidee.BUTTONS_X_NEG] = (robot.buttons[Spidee.BUTTONS_X_NEG]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_X_NEG] = robot.buttons[Spidee.BUTTONS_X_NEG]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_X_POS] = 0;
 		}
 		if( subject == buttonWalkForward ) {
-			robot.buttons[Spidee.BUTTONS_Y_POS] = (robot.buttons[Spidee.BUTTONS_Y_POS]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_Y_POS] = robot.buttons[Spidee.BUTTONS_Y_POS]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_Y_NEG] = 0;
 		}
 		if( subject == buttonWalkBackward ) {
-			robot.buttons[Spidee.BUTTONS_Y_NEG] = (robot.buttons[Spidee.BUTTONS_Y_NEG]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_Y_NEG] = robot.buttons[Spidee.BUTTONS_Y_NEG]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_Y_POS] = 0;
 		}
 		if( subject == buttonTurnDown ) {
-			robot.buttons[Spidee.BUTTONS_X_ROT_NEG] = (robot.buttons[Spidee.BUTTONS_X_ROT_NEG]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_X_ROT_NEG] = robot.buttons[Spidee.BUTTONS_X_ROT_NEG]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_X_ROT_POS] = 0;	
 		}
 		if( subject == buttonTurnUp ) {
-			robot.buttons[Spidee.BUTTONS_X_ROT_POS] = (robot.buttons[Spidee.BUTTONS_X_ROT_POS]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_X_ROT_POS] = robot.buttons[Spidee.BUTTONS_X_ROT_POS]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_X_ROT_NEG] = 0;
 		}
 		if( subject == buttonTurnLeft ) {
-			robot.buttons[Spidee.BUTTONS_Z_ROT_POS] = (robot.buttons[Spidee.BUTTONS_Z_ROT_POS]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_Z_ROT_POS] = robot.buttons[Spidee.BUTTONS_Z_ROT_POS]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_Z_ROT_NEG] = 0;
 		}
 		if( subject == buttonTurnRight ) {
-			robot.buttons[Spidee.BUTTONS_Z_ROT_NEG] = (robot.buttons[Spidee.BUTTONS_Z_ROT_NEG]==1? 0:1);
+			robot.buttons[Spidee.BUTTONS_Z_ROT_NEG] = robot.buttons[Spidee.BUTTONS_Z_ROT_NEG]==1? 0:1;
 			robot.buttons[Spidee.BUTTONS_Z_ROT_POS] = 0;
 		}
 	}

--- a/src/main/java/com/marginallyclever/robotOverlord/Spidee/SpideeJoint.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/Spidee/SpideeJoint.java
@@ -10,7 +10,7 @@ public class SpideeJoint extends SpideeLocation implements Serializable {
 	 */
 	private static final long serialVersionUID = 5055658323708862756L;
 
-	public static final int ANGLE_HISTORY_LENGTH = (30*3);
+	public static final int ANGLE_HISTORY_LENGTH = 30*3;
 	
 	  float angle;
 	  int last_angle;

--- a/src/main/java/com/marginallyclever/robotOverlord/arm3/Arm3.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/arm3/Arm3.java
@@ -26,11 +26,11 @@ extends RobotWithConnection {
 	protected final static String hello = "HELLO WORLD! I AM ARM3 #";
 	
 	//machine dimensions
-	final static public float BASE_TO_SHOULDER_X   =(5.37f);  // measured in solidworks
-	final static public float BASE_TO_SHOULDER_Z   =(9.55f);  // measured in solidworks
-	final static public float SHOULDER_TO_ELBOW    =(25.0f);
-	final static public float ELBOW_TO_WRIST       =(25.0f);
-	final static public float WRIST_TO_FINGER      =(4.0f);
+	final static public float BASE_TO_SHOULDER_X   = 5.37f;  // measured in solidworks
+	final static public float BASE_TO_SHOULDER_Z   = 9.55f;  // measured in solidworks
+	final static public float SHOULDER_TO_ELBOW    = 25.0f;
+	final static public float ELBOW_TO_WRIST       = 25.0f;
+	final static public float WRIST_TO_FINGER      = 4.0f;
 	final static public float BASE_TO_SHOULDER_MINIMUM_LIMIT = 7.5f;
 	
 	static public float HOME_X = 13.05f;
@@ -767,7 +767,7 @@ extends RobotWithConnection {
 		// y' = ( -v*(- u*x - v*y - w*z)) * (1.0-C) + y*C + ( + w*x - u*z)*S
 		// z' = ( -w*(- u*x - v*y - w*z)) * (1.0-C) + z*C + ( - v*x + u*y)*S
 		
-		float a = (-u*x - v*y - w*z);
+		float a = -u*x - v*y - w*z;
 
 		return new Vector3f( (-u*a) * (1.0f-C) + x*C + ( -w*y + v*z)*S,
 							 (-v*a) * (1.0f-C) + y*C + (  w*x - u*z)*S,

--- a/src/main/java/com/marginallyclever/robotOverlord/model/Model.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/model/Model.java
@@ -425,7 +425,7 @@ public class Model implements Serializable {
 	
 	private void updateBuffers(GL2 gl2) {
 		int totalBufferSize = numTriangles*3*3;
-		int s=(Float.SIZE/8);  // bits per float / bits per byte = bytes per float
+		int s= Float.SIZE/8;  // bits per float / bits per byte = bytes per float
 
 		// bind a buffer
 		vertices.rewind();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat
