### PR TITLE
 fix linux64 packaging

### DIFF
--- a/src/main/assembly/application.xml
+++ b/src/main/assembly/application.xml
@@ -46,7 +46,7 @@
         <include>org.jogamp.jogl:jogl-all:jar:natives-linux-amd64</include>
       </includes>
       <unpackOptions>
-        <includes><include>*.dll</include></includes>
+        <includes><include>*.so</include></includes>
       </unpackOptions>
     </dependencySet>
         


### PR DESCRIPTION
there is a typo (`.dll` vs `.so`) in the jogamp section of `src/main/assembly/application.xml` preventing linux64 from running, without this fix, the class loader will try to load 32bit libs resulting in `ELFCLASS32` errors.