### PR TITLE
Fixing publish-javadoc-maven.yml

### DIFF
--- a/.github/workflows/publish-javadoc-maven.yml
+++ b/.github/workflows/publish-javadoc-maven.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc
+          java-distribution: temurin
           java-version: 21
-          target-folder: docs # url will be https://<username>.github.io/<repo>/javadoc, This can be left as nothing to generate javadocs in the root folder.
+          target-folder: docs
           project: maven # or gradle
-          # subdirectories: moduleA moduleB #for subdirectories support, needs to be run with custom command


### PR DESCRIPTION
In fact the problem is from this line:

https://github.com/MathieuSoysal/Javadoc-publisher.yml/blob/02c11e2d95506dfc612a74b032f6550d2c82fb0b/action.yml#L33

The `adopt` java distribution is not anymore supported, and we need to change the default java distribution to another.

_______

Source: 
- https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt
- https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

___

So I used `temurin` java distribution instead of `adopt`.
